### PR TITLE
Fix TouchEvents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@decsys/ellipse-component",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1219,9 +1219,9 @@
       "integrity": "sha512-XX6rHWrNIo//a94/JSVcf6tFTL2I8guxk+BsD1Kfq8e9GOdhSFEFHGxvR/HQq+Szl9ADnAsM1I2o3DZ5jDHKbg=="
     },
     "@decsys/rating-scales": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@decsys/rating-scales/-/rating-scales-1.0.0-beta.4.tgz",
-      "integrity": "sha512-dvwyE/9FlIZ5BFp04gc4AQvNiguGwTtZnc8KfSoUiYJocbRaKM8RNRBVuONuHMY7Btj+fKuNDq1C5kb8H16IVA==",
+      "version": "1.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@decsys/rating-scales/-/rating-scales-1.0.0-beta.6.tgz",
+      "integrity": "sha512-3PpX/CphAFYn6J9Pizc8dLiNYmoWuhXDbX4jxXRWacY/6Ki8nUihbVfBnxiRbxIeDCy0Z2zJm/TUY6PrmAfRkQ==",
       "requires": {
         "@pixi/app": "^5.0.0",
         "@pixi/constants": "^5.0.0-rc.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@decsys/ellipse-component",
   "componentName": "Ellipse",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "The Ellipse Scale component for the DECSYS Survey Platform",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -38,7 +38,7 @@
   "dependencies": {
     "@decsys/iaa": "^1.0.0-beta.4",
     "@decsys/param-types": "^1.0.0-beta.2",
-    "@decsys/rating-scales": "^1.0.0-beta.4",
+    "@decsys/rating-scales": "^1.0.0-beta.6",
     "styled-icons": "^7.6.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Updated `rating-scales` to use the fixed `EllipseScale` that works on touch devices such as smartphones.